### PR TITLE
Normative: Rename strictness to lineBreakStyle

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -55,8 +55,8 @@ emu-issue:before {
         1. Let _opt_ be a new Record.
         1. Let _matcher_ be ? GetOption(_options_, `"localeMatcher"`, `"string"`, &laquo; `"lookup"`, `"best fit"` &raquo;, `"best fit"`).
         1. Set _opt_.[[localeMatcher]] to _matcher_.
-        1. Let _strictness_ be ? GetOption(_options_, `"strictness"`, `"string"`,  « `"strict"`, `"normal"`, `"loose"` », `"normal"`).
-        1. Set _opt_.[[lb]] to _strictness_.
+        1. Let _lineBreakStyle_ be ? GetOption(_options_, `"lineBreakStyle"`, `"string"`,  « `"strict"`, `"normal"`, `"loose"` », `"normal"`).
+        1. Set _opt_.[[lb]] to _lineBreakStyle_.
         1. Let _r_ be ResolveLocale(%Segmenter%.[[AvailableLocales]], _requestedLocales_, _opt_, %Segmenter%.[[RelevantExtensionKeys]]).
         1. Set _segmenter_.[[Locale]] to the value of _r_.[[Locale]].
         1. If _options_ is *undefined*, then
@@ -66,7 +66,7 @@ emu-issue:before {
         1. Let _granularity_ be ? GetOption(_options_, `"granularity"`, `"string"`, « `"grapheme"`, `"word"`, `"sentence"`,  `"line"` », `"grapheme"`).
         1. Set _segmenter_.[[SegmenterGranularity]] to _granularity_.
         1. If _granularity_ is `"line"`,
-          1. Set _segmenter_.[[SegmenterStrictness]] to _r_.[[lb]].
+          1. Set _segmenter_.[[SegmenterLineBreakStyle]] to _r_.[[lb]].
         1. Return _segmenter_.
       </emu-alg>
     </emu-clause>
@@ -163,7 +163,7 @@ emu-issue:before {
         This function provides access to the locale and options computed during initialization of the object.
       </p>
       <p>
-        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this Segmenter object. (see <emu-xref href="#sec-segmenter-internal-slots"></emu-xref>): locale, granularity and strictness. Properties whose corresponding internal slots are not present are not assigned.
+        The function returns a new object whose properties and attributes are set as if constructed by an object literal assigning to each of the following properties the value of the corresponding internal slot of this Segmenter object. (see <emu-xref href="#sec-segmenter-internal-slots"></emu-xref>): locale, granularity and lineBreakStyle. Properties whose corresponding internal slots are not present are not assigned.
       </p>
     </emu-clause>
   </emu-clause>
@@ -178,7 +178,7 @@ emu-issue:before {
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used by the segmenter.</li>
       <li>[[SegmenterGranularity]] is one of the String values `"grapheme"`, `"word"`, `"sentence"`, or `"line"`, identifying the segmenter used.</li>
-      <li>[[SegmenterStrictness]] is present on Segmenter instances with line granularity. If present, it may be `"strict"`, `"normal"`, or `"loose"`.</li>
+      <li>[[SegmenterLineBreakStyle]] is present on Segmenter instances with line granularity. If present, it may be `"strict"`, `"normal"`, or `"loose"`.</li>
     </ul>
 
   </emu-clause>
@@ -207,7 +207,7 @@ emu-issue:before {
         1. Let _string_ be _iterator_.[[SegmentIteratorString]].
         1. Let _position_ be _iterator_.[[SegmentIteratorPosition]].
         1. If _direction_ is ~forwards~ and _position_ is the length of _string_, or if _direction_ is ~backwards~ and _position_ is *0*, return true.
-        1. Find the next or previous (based on _direction_) break in _string_ from the position _position_ based on the locale, granularity and strictness in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]] and, if present, _segmenter_.[[SegmenterStrictness]].
+        1. Find the next or previous (based on _direction_) break in _string_ from the position _position_ based on the locale, granularity and lineBreakStyle in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]] and, if present, _segmenter_.[[SegmenterLineBreakStyle]].
         1. Set _iterator_.[[SegmentIteratorBreakType]] to a string representing the type of break found, using one of the values found in the table <emu-xref href="#break-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
         1. Set _iterator_.[[SegmentIteratorPosition]] to the position of the newly found break point.
         1. Return *false*.


### PR DESCRIPTION
This is more consistent with naming in Unicode documents, as suggested
by @zbraniecki in
https://github.com/tc39/proposal-intl-segmenter/pull/24#discussion_r163043537