### PR TITLE
Normative: Fix index arithmetic and "done" return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ The `next` method finds the next boundary and returns an `IterationResult`, wher
 
 #### `%SegmentIterator%.prototype.following(from)`
 
-Move the iterator index to the boundary following the code unit index _from_ (or after its current index if _from_ is *undefined*). Returns *true* if the end of the string was reached.
+Move the iterator index to the boundary following the code unit index _from_ (or after its current index if _from_ is not provided). Returns *true* if the end of the string was reached.
 
 #### `%SegmentIterator%.prototype.preceding(from)`
 
-Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is *undefined*). Returns *true* if the beginning of the string was reached.
+Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is not provided). Returns *true* if the beginning of the string was reached.
 
 #### `get %SegmentIterator%.prototype.index`
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ This class iterates over segmentation boundaries of a particular string.
 
 The `next` method finds the next boundary and returns an `IterationResult`, where the `value` is an object with fields `index` and `precedingSegmentType`. `index` contains the code unit index immediately following the newly found boundary; the `precedingSegmentType` describes which sort of segment it precedes it (TODO: define possible values, not part of UTS). This method defines the iteration protocol support for SegmentIterators, and is present for convenience; other methods expose a richer API.
 
-#### `%SegmentIterator%.prototype.following(index)`
+#### `%SegmentIterator%.prototype.following(from)`
 
-Move the iterator to the next break position after the given code unit index _index_, or if no index is provided, after its current index. Returns *true* if the end of the string was reached.
+Move the iterator index to the boundary following the code unit index _from_ (or after its current index if _from_ is *undefined*). Returns *true* if the end of the string was reached.
 
-#### `%SegmentIterator%.prototype.preceding(index)`
+#### `%SegmentIterator%.prototype.preceding(from)`
 
-Move the iterator to the previous break position before the given code unit index _index_, or if no index is provided, before its current index. Returns *true* if the beginning of the string was reached.
+Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is *undefined*). Returns *true* if the beginning of the string was reached.
 
 #### `get %SegmentIterator%.prototype.index`
 

--- a/spec.html
+++ b/spec.html
@@ -344,7 +344,7 @@ emu-issue:before {
           1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
           1. If _from_ is not *undefined*,
             1. Let _from_ be ? ToIndex(_from_).
-            1. If _from_ &ge; _length_, throw a *RangeError* exception.
+            1. If _from_ &lt; 0 or _from_ &ge; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
           1. ! AdvanceSegmentIterator(_iterator_, ~forwards~).
           1. If _iterator_.[[SegmentIteratorIndex]] = _length_, return *true*.

--- a/spec.html
+++ b/spec.html
@@ -242,7 +242,7 @@ emu-issue:before {
 
     <emu-clause id="sec-AdvanceSegmentIterator" aoid="AdvanceSegmentIterator">
       <h1>AdvanceSegmentIterator ( _iterator_, _direction_ )</h1>
-      <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ direction _direction_. The operation attempts to advance the iterator in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value indicating whether or not iteration in the given direction was already complete. It performs the following steps:</p>
+      <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ _direction_. The operation attempts to advance the iterator in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value that is *true* if and only if iteration in the given direction was already complete. It performs the following steps:</p>
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
         1. Let _locale_ be _segmenter_.[[Locale]].
@@ -262,7 +262,7 @@ emu-issue:before {
           1. If no boundary was found, let _nextIndex_ be 0. Otherwise, let _nextIndex_ be the integer index in _string_ that immediately follows the boundary.
         1. Set _iterator_.[[SegmentIteratorIndex]] to _nextIndex_.
         1. If _nextIndex_ = 0, then
-          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to `undefined`.
+          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to *undefined*.
         1. Else
           1. Assert: _granularity_ is listed in the &ldquo;Granularity&rdquo; column of <emu-xref href="#segment-type-table"></emu-xref>.
           1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that precedes the code unit at index _nextIndex_ - 1.
@@ -280,7 +280,7 @@ emu-issue:before {
           </tr>
           <tr>
             <td>`"grapheme"`</td>
-            <td>`undefined`</td>
+            <td>*undefined*</td>
             <td>a grapheme cluster</td>
           </tr>
           <tr>
@@ -337,12 +337,12 @@ emu-issue:before {
 
       <emu-clause id="sec-segment-iterator-prototype-following">
         <h1>%SegmentIteratorPrototype%.following( [ _from_ ] )</h1>
-        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns a Boolean value indicating whether or not the end of the string was reached. It performs the following steps:</p>
+        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns a Boolean value that is *true* if and only if the end of the string was reached. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[SegmentIteratorSegmenter]] internal slot, throw a *TypeError* exception.
           1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
-          1. If _from_ is not *undefined*,
+          1. If _from_ is not *undefined*, then
             1. Let _from_ be ? ToIndex(_from_).
             1. If _from_ &lt; 0 or _from_ &ge; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
@@ -354,14 +354,14 @@ emu-issue:before {
 
       <emu-clause id="sec-segment-iterator-prototype-preceding">
         <h1>%SegmentIteratorPrototype%.preceding( [ _from_ ] )</h1>
-        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns a Boolean value indicating whether or not the beginning of the string was reached. It performs the following steps:</p>
+        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns a Boolean value that is *true* if and only if the beginning of the string was reached. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[SegmentIteratorSegmenter]] internal slot, throw a *TypeError* exception.
-          1. If _from_ is not *undefined*,
+          1. If _from_ is not *undefined*, then
             1. Let _from_ be ? ToIndex(_from_).
             1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
-            1. If _from_ &gt; _length_ or _from_ = 0, throw a *RangeError* exception.
+            1. If _from_ = 0 or _from_ &gt; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
           1. ! AdvanceSegmentIterator(_iterator_, ~backwards~).
           1. If _iterator_.[[SegmentIteratorIndex]] = 0, return *true*.

--- a/spec.html
+++ b/spec.html
@@ -246,16 +246,16 @@ emu-issue:before {
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
         1. Let _string_ be _iterator_.[[SegmentIteratorString]].
-        1. Let _index_ be _iterator_.[[SegmentIteratorIndex]].
+        1. Let _lastIndex_ be _iterator_.[[SegmentIteratorIndex]].
         1. Let _len_ be the length of _string_.
         1. If _direction_ is ~forwards~, then
-          1. If _index_ is _len_, return *true*.
-          1. Find the first boundary in _string_ following the boundary immediately preceding code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+          1. If _lastIndex_ is _len_, return *true*.
+          1. Find the first boundary in _string_ following the boundary immediately preceding code unit index _lastIndex_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
           1. Assert: A boundary was found.
         1. Else
           1. Assert: _direction_ is ~backwards~.
-          1. If _index_ is *0*, return *true*.
-          1. Find the last boundary in _string_ preceding the boundary immediately preceding code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+          1. If _lastIndex_ is *0*, return *true*.
+          1. Find the last boundary in _string_ preceding the boundary immediately preceding code unit index _lastIndex_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
           1. If no boundary was found, proceed as if a boundary was found at the beginning of _string_.
         1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value representing the type of the segment which precedes the boundary, using one of the values found in the table <emu-xref href="#preceding-segment-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
         1. Set _iterator_.[[SegmentIteratorIndex]] to the index of the code unit which immediately follows the newly found boundary.

--- a/spec.html
+++ b/spec.html
@@ -243,6 +243,7 @@ emu-issue:before {
     <emu-clause id="sec-AdvanceSegmentIterator" aoid="AdvanceSegmentIterator">
       <h1>AdvanceSegmentIterator ( _iterator_, _direction_ )</h1>
       <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ _direction_. The operation attempts to advance the iterator to the next boundary in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value that is *true* if and only if iteration in the given direction was already complete. It performs the following steps:</p>
+      <emu-note>Boundary determination is implementation-dependent, but general default algorithms are specified in Unicode Standard Annex 29 (available at <a href="https://www.unicode.org/reports/tr29/">https://www.unicode.org/reports/tr29/</a>). It is recommended that implementations use locale-sensitive tailorings such as those provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).</emu-note>
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
         1. Let _locale_ be _segmenter_.[[Locale]].
@@ -305,7 +306,6 @@ emu-issue:before {
           </tr>
         </table>
       </emu-table>
-      <emu-note>This specification does not require a specific algorithm, but an algorithm for all breaks is specified in UTS 29.</emu-note>
     </emu-clause>
 
     <emu-clause id="sec-segment-iterator-prototype">

--- a/spec.html
+++ b/spec.html
@@ -242,7 +242,7 @@ emu-issue:before {
 
     <emu-clause id="sec-AdvanceSegmentIterator" aoid="AdvanceSegmentIterator">
       <h1>AdvanceSegmentIterator ( _iterator_, _direction_ )</h1>
-      <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ _direction_. The operation attempts to advance the iterator in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value that is *true* if and only if iteration in the given direction was already complete. It performs the following steps:</p>
+      <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ _direction_. The operation attempts to advance the iterator to the next boundary in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value that is *true* if and only if iteration in the given direction was already complete. It performs the following steps:</p>
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
         1. Let _locale_ be _segmenter_.[[Locale]].

--- a/spec.html
+++ b/spec.html
@@ -248,8 +248,15 @@ emu-issue:before {
         1. Let _string_ be _iterator_.[[SegmentIteratorString]].
         1. Let _index_ be _iterator_.[[SegmentIteratorIndex]].
         1. Let _len_ be the length of _string_.
-        1. If _direction_ is ~forwards~ and _index_ is _len_, or if _direction_ is ~backwards~ and _index_ is *0*, return *true*.
-        1. Find the next or previous (based on _direction_) boundary in _string_ from the boundary immediately preceding code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+        1. If _direction_ is ~forwards~, then
+          1. If _index_ is _len_, return *true*.
+          1. Find the first boundary in _string_ following the boundary immediately preceding code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+          1. Assert: A boundary was found.
+        1. Else
+          1. Assert: _direction_ is ~backwards~.
+          1. If _index_ is *0*, return *true*.
+          1. Find the last boundary in _string_ preceding the boundary immediately preceding code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+          1. If no boundary was found, proceed as if a boundary was found at the beginning of _string_.
         1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value representing the type of the segment which precedes the boundary, using one of the values found in the table <emu-xref href="#preceding-segment-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
         1. Set _iterator_.[[SegmentIteratorIndex]] to the index of the code unit which immediately follows the newly found boundary.
         1. Return *false*.

--- a/spec.html
+++ b/spec.html
@@ -346,7 +346,7 @@ emu-issue:before {
             1. Let _from_ be ? ToIndex(_from_).
             1. If _from_ &lt; 0 or _from_ &ge; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
-          1. ! AdvanceSegmentIterator(_iterator_, ~forwards~).
+          1. Perform ! AdvanceSegmentIterator(_iterator_, ~forwards~).
           1. If _iterator_.[[SegmentIteratorIndex]] = _length_, return *true*.
           1. Return *false*.
         </emu-alg>
@@ -363,7 +363,7 @@ emu-issue:before {
             1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
             1. If _from_ = 0 or _from_ &gt; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
-          1. ! AdvanceSegmentIterator(_iterator_, ~backwards~).
+          1. Perform ! AdvanceSegmentIterator(_iterator_, ~backwards~).
           1. If _iterator_.[[SegmentIteratorIndex]] = 0, return *true*.
           1. Return *false*.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -343,20 +343,24 @@ emu-issue:before {
 
       <emu-clause id="sec-segment-iterator-prototype-following">
         <h1>%SegmentIteratorPrototype%.following( [ _from_ ] )</h1>
+        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns a Boolean value indicating whether or not the end of the string was reached. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[SegmentIteratorSegmenter]] internal slot, throw a *TypeError* exception.
+          1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
           1. If _from_ is not *undefined*,
             1. Let _from_ be ? ToIndex(_from_).
-            1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
             1. If _from_ &ge; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
-          1. return AdvanceSegmentIterator(_iterator_, ~forwards~).
+          1. ! AdvanceSegmentIterator(_iterator_, ~forwards~).
+          1. If _iterator_.[[SegmentIteratorIndex]] = _length_, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-segment-iterator-prototype-preceding">
         <h1>%SegmentIteratorPrototype%.preceding( [ _from_ ] )</h1>
+        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns a Boolean value indicating whether or not the beginning of the string was reached. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[SegmentIteratorSegmenter]] internal slot, throw a *TypeError* exception.
@@ -365,7 +369,9 @@ emu-issue:before {
             1. Let _length_ be the length of _iterator_.[[SegmentIteratorString]].
             1. If _from_ &gt; _length_ or _from_ = 0, throw a *RangeError* exception.
             1. Let _iterator_.[[SegmentIteratorIndex]] be _from_.
-          1. return AdvanceSegmentIterator(_iterator_, ~backwards~).
+          1. ! AdvanceSegmentIterator(_iterator_, ~backwards~).
+          1. If _iterator_.[[SegmentIteratorIndex]] = 0, return *true*.
+          1. Return *false*.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -245,27 +245,37 @@ emu-issue:before {
       <p>When the abstract operation AdvanceSegmentIterator is called with a segment iterator _iterator_ and a direction either ~forwards~ or ~backwards~ _direction_, the following steps are taken:</p>
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
+        1. Let _locale_ be _segmenter_.[[Locale]].
+        1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
         1. Let _string_ be _iterator_.[[SegmentIteratorString]].
         1. Let _lastIndex_ be _iterator_.[[SegmentIteratorIndex]].
-        1. Let _len_ be the length of _string_.
         1. If _direction_ is ~forwards~, then
+          1. Let _len_ be the length of _string_.
           1. If _lastIndex_ is _len_, return *true*.
-          1. Find the first boundary in _string_ following the boundary immediately preceding code unit index _lastIndex_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
+          1. Using locale _locale_ and granularity _granularity_, find the first boundary in _string_ that follows the code unit at index _lastIndex_.
           1. Assert: A boundary was found.
+          1. If the boundary is at the end of _string_, let _nextIndex_ be _len_. Otherwise, let _nextIndex_ be the integer index in _string_ that immediately follows the boundary.
         1. Else
           1. Assert: _direction_ is ~backwards~.
           1. If _lastIndex_ is *0*, return *true*.
-          1. Find the last boundary in _string_ preceding the boundary immediately preceding code unit index _lastIndex_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
-          1. If no boundary was found, proceed as if a boundary was found at the beginning of _string_.
-        1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value representing the type of the segment which precedes the boundary, using one of the values found in the table <emu-xref href="#preceding-segment-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
-        1. Set _iterator_.[[SegmentIteratorIndex]] to the index of the code unit which immediately follows the newly found boundary.
+          1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that precedes the code unit at index _lastIndex_ - 1.
+          1. If no boundary was found, let _nextIndex_ be 0. Otherwise, let _nextIndex_ be the integer index in _string_ that immediately follows the boundary.
+        1. Set _iterator_.[[SegmentIteratorIndex]] to _nextIndex_.
+        1. If _nextIndex_ = 0, then
+          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to `undefined`.
+        1. Else
+          1. Assert: _granularity_ is listed in the &ldquo;Granularity&rdquo; column of <emu-xref href="#segment-type-table"></emu-xref>.
+          1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that precedes the code unit at index _nextIndex_ - 1.
+          1. If no boundary was found, let _segmentStart_ be 0. Otherwise, let _segmentStart_ be the integer index in _string_ that immediately follows the boundary.
+          1. Let _precedingSegment_ be the String value containing consecutive code units from _string_ beginning with the code unit at index _segmentStart_ and ending with the code unit at index _nextIndex_ - 1.
+          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value from the &ldquo;Segment Type&rdquo; column of <emu-xref href="#segment-type-table"></emu-xref> describing _precedingSegment_ according to granularity _granularity_ and locale _locale_ and the &ldquo;Meaning&rdquo; column.
         1. Return *false*.
       </emu-alg>
-      <emu-table id="preceding-segment-type-table" caption="[[SegmentIteratorPrecedingSegmentType]] values">
+      <emu-table id="segment-type-table" caption="Segment Types">
         <table>
           <tr>
             <th>Granularity</th>
-            <th>precedingSegmentType</th>
+            <th>Segment Type</th>
             <th>Meaning</th>
           </tr>
           <tr>

--- a/spec.html
+++ b/spec.html
@@ -242,7 +242,7 @@ emu-issue:before {
 
     <emu-clause id="sec-AdvanceSegmentIterator" aoid="AdvanceSegmentIterator">
       <h1>AdvanceSegmentIterator ( _iterator_, _direction_ )</h1>
-      <p>When the abstract operation AdvanceSegmentIterator is called with a segment iterator _iterator_ and a direction either ~forwards~ or ~backwards~ _direction_, the following steps are taken:</p>
+      <p>The abstract operation AdvanceSegmentIterator takes as arguments a segment iterator _iterator_ and a ~forwards~ or ~backwards~ direction _direction_. The operation attempts to advance the iterator in the given direction according to the effective locale and options of the iterator's constructing segmenter, and returns a Boolean value indicating whether or not iteration in the given direction was already complete. It performs the following steps:</p>
       <emu-alg>
         1. Let _segmenter_ be _iterator_.[[SegmentIteratorSegmenter]].
         1. Let _locale_ be _segmenter_.[[Locale]].

--- a/spec.html
+++ b/spec.html
@@ -268,7 +268,7 @@ emu-issue:before {
           1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that precedes the code unit at index _nextIndex_ - 1.
           1. If no boundary was found, let _segmentStart_ be 0. Otherwise, let _segmentStart_ be the integer index in _string_ that immediately follows the boundary.
           1. Let _precedingSegment_ be the String value containing consecutive code units from _string_ beginning with the code unit at index _segmentStart_ and ending with the code unit at index _nextIndex_ - 1.
-          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value from the &ldquo;Segment Type&rdquo; column of <emu-xref href="#segment-type-table"></emu-xref> describing _precedingSegment_ according to granularity _granularity_ and locale _locale_ and the &ldquo;Meaning&rdquo; column.
+          1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to the value from the &ldquo;Segment Type&rdquo; column of the row in <emu-xref href="#segment-type-table"></emu-xref> in which the &ldquo;Granularity&rdquo; column matches _granularity_ and the &ldquo;Meaning&rdquo; column describes _precedingSegment_ according to the locale _locale_.
         1. Return *false*.
       </emu-alg>
       <emu-table id="segment-type-table" caption="Segment Types">
@@ -281,33 +281,27 @@ emu-issue:before {
           <tr>
             <td>`"grapheme"`</td>
             <td>`undefined`</td>
-            <td></td>
-          </tr>
-          <tr>
-            <td rowspan=2>`"word"`</td>
-            <td>`"none"`</td>
-            <td>"words" that do not fit into any of other categories. Includes spaces and most punctuation.</td>
+            <td>a grapheme cluster</td>
           </tr>
           <tr>
             <td>`"word"`</td>
-            <td>words that appear to be numbers, letters, kana characters, ideographic characters, etc</td>
+            <td>`"word"`</td>
+            <td>a segment containing numbers, letters, kana, ideographic characters, or other word-like contents</td>
           </tr>
           <tr>
-            <td rowspan=2>`"sentence"`</td>
+            <td>`"word"`</td>
+            <td>`"none"`</td>
+            <td>a segment that is not word-like, often consisting of spaces or punctuation</td>
+          </tr>
+          <tr>
+            <td>`"sentence"`</td>
             <td>`"term"`</td>
-            <td>
-              sentences ending with a sentence terminator
-              ('.', '?', '!', etc.) character, possibly followed by a
-              hard separator (CR, LF, PS, etc.)
-            </td>
+            <td>a segment that ends with a sentence terminator ('.', '?', '!', etc.) optionally followed by any amount of closing punctuation ('"', ']', '»', etc.), any amount of whitespace, and then an optional hard separator (CR, LF, PS, etc.)</td>
           </tr>
           <tr>
+            <td>`"sentence"`</td>
             <td>`"sep"`</td>
-            <td>
-              sentences that do not contain an ending
-              sentence terminator ('.', '?', '!', etc.) character, but
-              are ended only by a hard separator (CR, LF, PS, etc.)
-            </td>
+            <td>a segment that does not end with a sentence terminator ('.', '?', '!', etc.) section, but is either at the end of the string or ends with a hard separator (CR, LF, PS, etc.)</td>
           </tr>
         </table>
       </emu-table>


### PR DESCRIPTION
Ref https://github.com/tc39/proposal-intl-segmenter/pull/55#issuecomment-447862318

This PR separates the forwards and backwards logic in order to properly account for the nature of boundaries as falling _between_ code unit indexes (cf. [Unicode TR 29](http://unicode.org/reports/tr29/)).