### PR TITLE
Normative: Remove "segment" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ let segmenter = new Intl.Segmenter("fr", {granularity: "word"});
 let iterator = segmenter.segment("Ceci n'est pas une pipe");
 
 // Iterate over it!
-for (let {segment, breakType} of iterator) {
-  console.log(`segment: ${segment} breakType: ${breakType}`);
+for (let {index, breakType} of iterator) {
+  console.log(`index: ${index} breakType: ${breakType}`);
   break;
 }
 
 // logs the following to the console:
-// segment: Ceci breakType: letter
+// index: 4 breakType: letter
 ```
 
 ## API

--- a/spec.html
+++ b/spec.html
@@ -316,10 +316,8 @@ emu-issue:before {
           1. If _done_ is *true*, return CreateIterResultObject(*undefined*, *true*).
           1. Let _newIndex_ be _iterator_.[[SegmentIteratorIndex]].
           1. Let _string_ be _iterator_.[[SegmentIteratorString]].
-          1. Let _segment_ be the substring of _string_ from _previousIndex_ to _newIndex_, inclusive of _previousIndex_ and exclusive of _newIndex_.
           1. Let _breakType_ be _iterator_.[[SegmentIteratorBreakType]].
           1. Let _result_ be ! ObjectCreate(%ObjectPrototype%).
-          1. Perform ! CreateDataProperty(_result_ `"segment"`, _segment_).
           1. Perform ! CreateDataProperty(_result_, `"breakType"`, _breakType_).
           1. Perform ! CreateDataProperty(_result_, `"index"`, _newIndex_).
           1. Return CreateIterResultObject(_result_, *false*).


### PR DESCRIPTION
Once this property is removed, the `.next()` method will have feature
parity with iteration based on following/preceding. User code can
calculate the substrings itself.