### PR TITLE
Normative: Rename breakType to precedingSegmentType

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ let segmenter = new Intl.Segmenter("fr", {granularity: "word"});
 let iterator = segmenter.segment("Ceci n'est pas une pipe");
 
 // Iterate over it!
-for (let {segment, precedingSegmentType } of iterator) {
+for (let {segment, precedingSegmentType} of iterator) {
   console.log(`segment: ${segment} precedingSegmentType : ${precedingSegmentType}`);
   break;
 }

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ let segmenter = new Intl.Segmenter("fr", {granularity: "word"});
 let iterator = segmenter.segment("Ceci n'est pas une pipe");
 
 // Iterate over it!
-for (let {segment, breakType} of iterator) {
-  console.log(`segment: ${segment} breakType: ${breakType}`);
+for (let {segment, precedingSegmentType } of iterator) {
+  console.log(`segment: ${segment} precedingSegmentType : ${precedingSegmentType}`);
   break;
 }
 
 // logs the following to the console:
-// segment: Ceci breakType: letter
+// segment: Ceci precedingSegmentType: letter
 ```
 
 ## API
@@ -53,7 +53,7 @@ This class iterates over segmentation boundaries of a particular string.
 
 #### `%SegmentIterator%.prototype.next()`
 
-The `next` method, to use finds the next boundary and returns an `IterationResult`, where the `value` is an object with fields `segment` and `breakType`. The `segment` contains the substring between the previous break location and the newly found break location; the `breakType` describes which sort of segment it is (TODO: define possible values, not part of UTS). This method defines the iteration protocol support for SegmentIterators, and is present for convenience; other methods expose a richer API.
+The `next` method, to use finds the next boundary and returns an `IterationResult`, where the `value` is an object with fields `segment` and `precedingSegmentType`. The `segment` contains the substring between the previous break location and the newly found break location; the `precedingSegmentType` describes which sort of segment it is (TODO: define possible values, not part of UTS). This method defines the iteration protocol support for SegmentIterators, and is present for convenience; other methods expose a richer API.
 
 #### `%SegmentIterator%.prototype.following(index)`
 
@@ -67,9 +67,9 @@ Move the iterator to the previous break position before the given code unit inde
 
 Return the code unit index of the most recently discovered break position, as an offset from the beginning of the string. Initially the `index` is 0.
 
-#### `get %SegmentIterator%.prototype.breakType`
+#### `get %SegmentIterator%.prototype.precedingSegmentType`
 
-The `breakType` of the most recently discovered segment. If there is no current segment (e.g., a just-instantiated SegmentIterator, or one which has reached the end), or if the break type is "grapheme", then this will be `undefined`.
+The `precedingSegmentType` of the segment which precedes the current iterator location in logical order. If there is no preceding segment (e.g., a just-instantiated SegmentIterator), or if the break type is "grapheme", then this will be `undefined`.
 
 ## FAQ
 
@@ -95,10 +95,10 @@ A: Hyphenation is expected to have a different sort of API shape for various rea
 
 Q: Why is this API stateful?
 
-It would be possible to make a stateless API without a SegmentIterator, where instead, a Segmenter has two methods, with two arguments: a string and an offset, for finding the next break before or after. This method would return an object `{breakType, index}` similar to what `next()` returns in this API. However, there are a few downsides to this approach:
+It would be possible to make a stateless API without a SegmentIterator, where instead, a Segmenter has two methods, with two arguments: a string and an offset, for finding the next break before or after. This method would return an object `{precedingSegmentType, index}` similar to what `next()` returns in this API. However, there are a few downsides to this approach:
 - Performance:
   - Often, JavaScript implementations need to take an extra step to convert an input string into a form that's usable for the external internationalization library. When querying several break positions on a single string, it is nice to reuse the new form of the string; it would be difficult to cache this and invalidate the cache when appropriate.
-  - The `{breakType, index}` object may be a difficult allocation to optimize away. Some usages of this library are performance-sensitive and may benefit from a lighter-weight API which avoids the allocation.
+  - The `{precedingSegmentType, index}` object may be a difficult allocation to optimize away. Some usages of this library are performance-sensitive and may benefit from a lighter-weight API which avoids the allocation.
 - Convenience: Many (most?) usages of this API want to iterate through a string, either forwards or backwards, and get all of the appropriate breaks, possibly interspersed with doing related work. A stateful API may be more terse for this sort of use case--no need to keep track of the previous break position and feed it back in.
 
 It is easy to create a stateless API based on this stateful one, or vice versa, in user JavaScript code.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This class iterates over segmentation boundaries of a particular string.
 
 #### `%SegmentIterator%.prototype.next()`
 
-The `next` method, to use finds the next boundary and returns an `IterationResult`, where the `value` is an object with fields `segment` and `precedingSegmentType`. The `segment` contains the substring between the previous break location and the newly found break location; the `precedingSegmentType` describes which sort of segment it is (TODO: define possible values, not part of UTS). This method defines the iteration protocol support for SegmentIterators, and is present for convenience; other methods expose a richer API.
+The `next` method finds the next boundary and returns an `IterationResult`, where the `value` is an object with fields `index` and `precedingSegmentType`. `index` contains the code unit index immediately following the newly found boundary; the `precedingSegmentType` describes which sort of segment it precedes it (TODO: define possible values, not part of UTS). This method defines the iteration protocol support for SegmentIterators, and is present for convenience; other methods expose a richer API.
 
 #### `%SegmentIterator%.prototype.following(index)`
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Return the code unit index of the most recently discovered break position, as an
 
 #### `get %SegmentIterator%.prototype.precedingSegmentType`
 
-The `precedingSegmentType` of the segment which precedes the current iterator location in logical order. If there is no preceding segment (e.g., a just-instantiated SegmentIterator), or if the break type is "grapheme", then this will be `undefined`.
+The type of the segment which precedes the current iterator location in logical order. If there is no preceding segment (e.g., a just-instantiated SegmentIterator), or if the granularity is "grapheme", then this will be `undefined`.
 
 ## FAQ
 

--- a/spec.html
+++ b/spec.html
@@ -236,7 +236,7 @@ emu-issue:before {
         1. Let _iterator_.[[SegmentIteratorSegmenter]] be _segmenter_.
         1. Let _iterator_.[[SegmentIteratorString]] be _string_.
         1. Let _iterator_.[[SegmentIteratorIndex]] be *0*.
-        1. Let _iterator_.[[SegmentIteratorBreakType]] be *undefined*.
+        1. Let _iterator_.[[SegmentIteratorPrecedingSegmentType]] be *undefined*.
       </emu-alg>
     </emu-clause>
 
@@ -250,15 +250,15 @@ emu-issue:before {
         1. Let _len_ be the length of _string_.
         1. If _direction_ is ~forwards~ and _index_ is _len_, or if _direction_ is ~backwards~ and _index_ is *0*, return *true*.
         1. Find the next or previous (based on _direction_) break in _string_ from the code unit index _index_ based on the locale, and granularity in _segmenter_.[[Locale]], _segmenter_.[[SegmenterGranularity]].
-        1. Set _iterator_.[[SegmentIteratorBreakType]] to a value representing the type of break found, using one of the values found in the table <emu-xref href="#break-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
+        1. Set _iterator_.[[SegmentIteratorPrecedingSegmentType]] to a value representing the type of the segment which precedes the boundary, using one of the values found in the table <emu-xref href="#preceding-segment-type-table"></emu-xref>, or `undefined` if the boundaries of the string are reached, or if there is no meaningful type for the granularity.
         1. Set _iterator_.[[SegmentIteratorIndex]] to the code unit index of the newly found break position.
         1. Return *false*.
       </emu-alg>
-      <emu-table id="break-type-table" caption="[[SegmentIteratorBreakType]] values">
+      <emu-table id="preceding-segment-type-table" caption="[[SegmentIteratorPrecedingSegmentType]] values">
         <table>
           <tr>
             <th>Granularity</th>
-            <th>breakType</th>
+            <th>precedingSegmentType</th>
             <th>Meaning</th>
           </tr>
           <tr>
@@ -317,10 +317,10 @@ emu-issue:before {
           1. Let _newIndex_ be _iterator_.[[SegmentIteratorIndex]].
           1. Let _string_ be _iterator_.[[SegmentIteratorString]].
           1. Let _segment_ be the substring of _string_ from _previousIndex_ to _newIndex_, inclusive of _previousIndex_ and exclusive of _newIndex_.
-          1. Let _breakType_ be _iterator_.[[SegmentIteratorBreakType]].
+          1. Let _precedingSegmentType_ be _iterator_.[[SegmentIteratorPrecedingSegmentType]].
           1. Let _result_ be ! ObjectCreate(%ObjectPrototype%).
           1. Perform ! CreateDataProperty(_result_ `"segment"`, _segment_).
-          1. Perform ! CreateDataProperty(_result_, `"breakType"`, _breakType_).
+          1. Perform ! CreateDataProperty(_result_, `"precedingSegmentType"`, _precedingSegmentType_).
           1. Perform ! CreateDataProperty(_result_, `"index"`, _newIndex_).
           1. Return CreateIterResultObject(_result_, *false*).
         </emu-alg>
@@ -363,12 +363,12 @@ emu-issue:before {
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-segment-iterator-prototype-breakType">
-        <h1>get %SegmentIteratorPrototype%.breakType</h1>
+      <emu-clause id="sec-segment-iterator-prototype-precedingSegmentType">
+        <h1>get %SegmentIteratorPrototype%.precedingSegmentType</h1>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[SegmentIteratorSegmenter]] internal slot, throw a *TypeError* exception.
-          1. Return _iterator_.[[SegmentIteratorBreakType]].
+          1. Return _iterator_.[[SegmentIteratorPrecedingSegmentType]].
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
Following the resolution in #59