### PR TITLE
Normative: Resolve following/preceding behavior, including edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Move the iterator index to the boundary following the code unit index _from_ (or
 
 Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is not provided). Returns *true* if the beginning of the string was reached.
 
+#### `get %BoundaryIterator%.prototype.atEnd`
+
+Return true if the current iterator location is at the end of the string, otherwise return false.
+
 #### `get %BoundaryIterator%.prototype.index`
 
 Return the current boundary position as a count of code units in string that precede it. The initial value is 0, corresponding to a boundary at the start of the string.

--- a/README.md
+++ b/README.md
@@ -60,38 +60,36 @@ let segmenter = new Intl.Segmenter("fr", {granularity: "word"});
 let boundaries = segmenter.segment(input);
 let done = false;
 
-boundaries.index                // → 0
-boundaries.precedingSegmentType // → undefined
+boundaries.index                     // → 0
+boundaries.precedingSegmentType      // → undefined
 
-done = boundaries.following()   // → false
-boundaries.index                // → 6
-boundaries.precedingSegmentType // → "word" (describing "Allons")
+done = boundaries.following().atEnd  // → false
+boundaries.index                     // → 6
+boundaries.precedingSegmentType      // → "word" (describing "Allons")
 
-done = boundaries.following(5)  // → false
-boundaries.index                // → 6
-boundaries.precedingSegmentType // → "word" (describing "Allons")
+done = boundaries.following(5).atEnd // → false
+boundaries.index                     // → 6
+boundaries.precedingSegmentType      // → "word" (describing "Allons")
 
-done = boundaries.following()   // → false
-boundaries.index                // → 7
-boundaries.precedingSegmentType // → "none" (describing "-")
+done = boundaries.following().atEnd  // → false
+boundaries.index                     // → 7
+boundaries.precedingSegmentType      // → "none" (describing "-")
 
-done = boundaries.following(8)  // → true
-boundaries.index                // → 9
-boundaries.precedingSegmentType // → "none" (describing "!")
+done = boundaries.following(8).atEnd // → true
+boundaries.index                     // → 9
+boundaries.precedingSegmentType      // → "none" (describing "!")
 
-done = boundaries.following()   // → RangeError
-boundaries.index                // → 9
+done = boundaries.following().atEnd  // → RangeError
+boundaries.index                     // → 9
 
-done = boundaries.preceding()   // → false
-boundaries.index                // → 8
-boundaries.precedingSegmentType // → "word" (describing "y")
+boundaries.preceding().index         // → 8
+boundaries.precedingSegmentType      // → "word" (describing "y")
 
-done = boundaries.preceding(3)  // → false
-boundaries.index                // → 0
-boundaries.precedingSegmentType // → undefined
+boundaries.preceding(3).index        // → 0
+boundaries.precedingSegmentType      // → undefined
 
-done = boundaries.preceding()   // → RangeError
-boundaries.index                // → 0
+boundaries.preceding()               // → RangeError
+boundaries.index                     // → 0
 ```
 
 ## API
@@ -127,11 +125,11 @@ The `next` method implements the <i>Iterator</i> interface, finding the next bou
 
 #### `%BoundaryIterator%.prototype.following(from)`
 
-Move the iterator index to the boundary following the code unit index _from_ (or after its current index if _from_ is not provided). Returns *true* if the end of the string was reached.
+Move the iterator index to the boundary following the code unit index _from_ (or after its current index if _from_ is not provided). Returns the iterator.
 
 #### `%BoundaryIterator%.prototype.preceding(from)`
 
-Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is not provided). Returns *true* if the beginning of the string was reached.
+Move the iterator index to the boundary preceding the position before the code unit index _from_ (or before its current index if _from_ is not provided). Returns the iterator.
 
 #### `get %BoundaryIterator%.prototype.atEnd`
 

--- a/spec.html
+++ b/spec.html
@@ -252,14 +252,14 @@ emu-issue:before {
         1. Let _lastIndex_ be _iterator_.[[BoundaryIteratorIndex]].
         1. If _direction_ is ~forwards~, then
           1. Let _len_ be the length of _string_.
-          1. If _lastIndex_ is _len_, return *true*.
-          1. Using locale _locale_ and granularity _granularity_, find the first boundary in _string_ that follows the code unit at index _lastIndex_.
+          1. If _lastIndex_ &ge; _len_, return *true*.
+          1. Using locale _locale_ and granularity _granularity_, find the first boundary in _string_ that follows more than _lastIndex_ code units.
           1. Assert: A boundary was found.
           1. If the boundary is at the end of _string_, let _nextIndex_ be _len_. Otherwise, let _nextIndex_ be the integer index in _string_ that immediately follows the boundary.
         1. Else
           1. Assert: _direction_ is ~backwards~.
-          1. If _lastIndex_ is *0*, return *true*.
-          1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that precedes the code unit at index _lastIndex_ - 1.
+          1. If _lastIndex_ &le; *0*, return *true*.
+          1. Using locale _locale_ and granularity _granularity_, find the last boundary in _string_ that follows fewer than _lastIndex_ code units.
           1. If no boundary was found, let _nextIndex_ be 0. Otherwise, let _nextIndex_ be the integer index in _string_ that immediately follows the boundary.
         1. Set _iterator_.[[BoundaryIteratorIndex]] to _nextIndex_.
         1. If _nextIndex_ = 0, then
@@ -336,32 +336,40 @@ emu-issue:before {
       </emu-clause>
 
       <emu-clause id="sec-boundary-iterator-prototype-following">
-        <h1>%BoundaryIteratorPrototype%.following( [ _from_ ] )</h1>
-        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns the iterator. It performs the following steps:</p>
+        <h1>%BoundaryIteratorPrototype%.following( [ _fromIndex_ ] )</h1>
+        <p>The `following` method moves the iterator index to the boundary following the code unit index _fromIndex_ (or after the current index of the iterator if _fromIndex_ is *undefined*) and returns the iterator. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[BoundaryIteratorSegmenter]] internal slot, throw a *TypeError* exception.
-          1. Let _length_ be the length of _iterator_.[[BoundaryIteratorString]].
-          1. If _from_ is not *undefined*, then
-            1. Let _from_ be ? ToIndex(_from_).
-            1. If _from_ &lt; 0 or _from_ &ge; _length_, throw a *RangeError* exception.
-            1. Let _iterator_.[[BoundaryIteratorIndex]] be _from_.
+          1. Let _len_ be the length of _iterator_.[[BoundaryIteratorString]].
+          1. If _fromIndex_ is *undefined*, then
+            1. Let _n_ be _iterator_.[[BoundaryIteratorIndex]].
+            1. If _n_ &ge; _len_, throw a *RangeError* exception.
+          1. Else
+            1. Let _n_ be ? ToInteger(_fromIndex_).
+            1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
+            1. If _n_ &ge; _len_, throw a *RangeError* exception.
+            1. Set _iterator_.[[BoundaryIteratorIndex]] to _n_.
           1. Perform ! AdvanceBoundaryIterator(_iterator_, ~forwards~).
           1. Return _iterator_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-boundary-iterator-prototype-preceding">
-        <h1>%BoundaryIteratorPrototype%.preceding( [ _from_ ] )</h1>
-        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns the iterator. It performs the following steps:</p>
+        <h1>%BoundaryIteratorPrototype%.preceding( [ _fromIndex_ ] )</h1>
+        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _fromIndex_ (or before the current index of the iterator if _fromIndex_ is *undefined*) and returns the iterator. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[BoundaryIteratorSegmenter]] internal slot, throw a *TypeError* exception.
-          1. If _from_ is not *undefined*, then
-            1. Let _from_ be ? ToIndex(_from_).
-            1. Let _length_ be the length of _iterator_.[[BoundaryIteratorString]].
-            1. If _from_ = 0 or _from_ &gt; _length_, throw a *RangeError* exception.
-            1. Let _iterator_.[[BoundaryIteratorIndex]] be _from_.
+          1. If _fromIndex_ is *undefined*, then
+            1. Let _n_ be _iterator_.[[BoundaryIteratorIndex]].
+            1. If _n_ &le; 0, throw a *RangeError* exception.
+          1. Else
+            1. Let _len_ be the length of _iterator_.[[BoundaryIteratorString]].
+            1. Let _n_ be ? ToInteger(_fromIndex_).
+            1. Assert: If _fromIndex_ is *undefined*, then _n_ is 0.
+            1. If _n_ &le; 0, throw a *RangeError* exception.
+            1. Set _iterator_.[[BoundaryIteratorIndex]] to _n_.
           1. Perform ! AdvanceBoundaryIterator(_iterator_, ~backwards~).
           1. Return _iterator_.
         </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -337,7 +337,7 @@ emu-issue:before {
 
       <emu-clause id="sec-boundary-iterator-prototype-following">
         <h1>%BoundaryIteratorPrototype%.following( [ _from_ ] )</h1>
-        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns a Boolean value that is *true* if and only if the end of the string was reached. It performs the following steps:</p>
+        <p>The `following` method moves the iterator index to the boundary following the code unit index _from_ (or after the current index of the iterator if _from_ is *undefined*) and returns the iterator. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[BoundaryIteratorSegmenter]] internal slot, throw a *TypeError* exception.
@@ -347,14 +347,13 @@ emu-issue:before {
             1. If _from_ &lt; 0 or _from_ &ge; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[BoundaryIteratorIndex]] be _from_.
           1. Perform ! AdvanceBoundaryIterator(_iterator_, ~forwards~).
-          1. If _iterator_.[[BoundaryIteratorIndex]] = _length_, return *true*.
-          1. Return *false*.
+          1. Return _iterator_.
         </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-boundary-iterator-prototype-preceding">
         <h1>%BoundaryIteratorPrototype%.preceding( [ _from_ ] )</h1>
-        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns a Boolean value that is *true* if and only if the beginning of the string was reached. It performs the following steps:</p>
+        <p>The `preceding` method moves the iterator index to the boundary preceding the position before the code unit index _from_ (or before the current index of the iterator if _from_ is *undefined*) and returns the iterator. It performs the following steps:</p>
         <emu-alg>
           1. Let _iterator_ be *this* value.
           1. If _iterator_ does not have a [[BoundaryIteratorSegmenter]] internal slot, throw a *TypeError* exception.
@@ -364,8 +363,7 @@ emu-issue:before {
             1. If _from_ = 0 or _from_ &gt; _length_, throw a *RangeError* exception.
             1. Let _iterator_.[[BoundaryIteratorIndex]] be _from_.
           1. Perform ! AdvanceBoundaryIterator(_iterator_, ~backwards~).
-          1. If _iterator_.[[BoundaryIteratorIndex]] = 0, return *true*.
-          1. Return *false*.
+          1. Return _iterator_.
         </emu-alg>
       </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -369,6 +369,17 @@ emu-issue:before {
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-boundary-iterator-prototype-atEnd">
+        <h1>get %BoundaryIteratorPrototype%.atEnd</h1>
+        <emu-alg>
+          1. Let _iterator_ be *this* value.
+          1. If _iterator_ does not have a [[BoundaryIteratorSegmenter]] internal slot, throw a *TypeError* exception.
+          1. Let _length_ be the length of _iterator_.[[BoundaryIteratorString]].
+          1. If _iterator_.[[BoundaryIteratorIndex]] = _length_, return *true*.
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-boundary-iterator-prototype-index">
         <h1>get %BoundaryIteratorPrototype%.index</h1>
         <emu-alg>


### PR DESCRIPTION
Fixes #82

* Introduce `%BoundaryIteratorPrototype%.atEnd`.
* Fix the following/preceding boolean trap by returning the `this` receiver instead.
* Allow any `.following`/`.preceding` fromIndex that finds a boundary (e.g., `boundaries.following(-1)` and `boundaries.preceding(Infinity)`).