### PR TITLE
Editorial: Simplify the spec by split FindBoundary 

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -277,8 +277,8 @@ emu-issue:before {
           1. Let _len_ be the length of _string_.
           1. Let _n_ be ? ToInteger(_index_).
           1. If _n_ &lt; 0 or _n_ &ge; _len_, return *undefined*.
-          1. Let _startIndex_ be ! FindBoundary(_segmenter_, _string_, _n_, ~before~).
-          1. Let _endIndex_ be ! FindBoundary(_segmenter_, _string_, _n_, ~after~).
+          1. Let _startIndex_ be ! FindBoundaryBefore(_segmenter_, _string_, _n_).
+          1. Let _endIndex_ be ! FindBoundaryAfter(_segmenter_, _string_, _n_).
           1. Return ! CreateSegmentDataObject(_segmenter_, _string_, _startIndex_, _endIndex_).
         </emu-alg>
       </emu-clause>
@@ -362,8 +362,8 @@ emu-issue:before {
           1. Let _segmenter_ be _iterator_.[[IteratingSegmenter]].
           1. Let _string_ be _iterator_.[[IteratedString]].
           1. Let _startIndex_ be _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]].
-          1. Let _endIndex_ be ! FindBoundary(_segmenter_, _string_, _startIndex_, ~after~).
-          1. If _endIndex_ is not finite, then
+          1. Let _endIndex_ be ! FindBoundaryAfter(_segmenter_, _string_, _startIndex_).
+          1. If _endIndex_ is *-1*, then
             1. Return ! CreateIterResultObject(*undefined*, *true*).
           1. Set _iterator_.[[IteratedStringNextSegmentCodeUnitIndex]] to _endIndex_.
           1. Let _segmentData_ be ! CreateSegmentDataObject(_segmenter_, _string_, _startIndex_, _endIndex_).
@@ -430,12 +430,12 @@ emu-issue:before {
         1. Assert: _endIndex_ &le; _len_.
         1. Assert: _startIndex_ &lt; _endIndex_.
         1. Let _result_ be ! ObjectCreate(%ObjectPrototype%).
-        1. Let _segment_ be the String value containing consecutive code units from _string_ beginning with the code unit at index _startIndex_ and ending with the code unit at index _endIndex_ - 1.
+        1. Let _segment_ be the String value equal to the substring of _string_ consisting of the code units at indices _startIndex_ (inclusive) through _endIndex_ (exclusive).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"segment"*, _segment_).
         1. Perform ! CreateDataPropertyOrThrow(_result_, *"index"*, _startIndex_).
         1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
         1. If _granularity_ is `"word"`, then
-          1. Let _isWordLike_ be a Boolean value indicating whether the word segment _segment_ in _string_ is "word-like" according to locale _segmenter_.[[Locale]].
+          1. Let _isWordLike_ be a Boolean value indicating whether _segment_ is "word-like" according to locale _segmenter_.[[Locale]].
           <emu-note>Whether a segment is "word-like" is implementation-dependent, and implementations are recommended to use locale-sensitive tailorings. In general, segments consisting solely of spaces and/or punctuation (such as those terminated with "WORD_NONE" boundaries by ICU [International Components for Unicode, documented at <a href="https://unicode-org.github.io/icu-docs/">https://unicode-org.github.io/icu-docs/</a>]) are not considered to be "word-like".</emu-note>
         1. Else
           1. Let _isWordLike_ be *undefined*.
@@ -452,24 +452,33 @@ emu-issue:before {
       A Segment Data Object is an object that represents a particular segment from a string.
     </p>
 
-    <emu-clause id="sec-findboundary" aoid="FindBoundary">
-      <h1>FindBoundary ( _segmenter_, _string_, _startIndex_, _direction_ )</h1>
-      <p>The FindBoundary abstract operation is called with arguments Intl.Segmenter instance _segmenter_, String value _string_, integer Number value _startIndex_, and _direction_ (which must be ~before~ or ~after~) to find a segmentation boundary between two code units in _string_ in the specified _direction_ from the code unit at index _startIndex_ according to the locale and options of _segmenter_ and return the immediately following code unit index (which will be infinite if no such boundary exists). The following steps are taken:</p>
+    <emu-clause id="sec-findboundary-before" aoid="FindBoundaryBefore">
+      <h1>FindBoundaryBefore ( _segmenter_, _string_, _startIndex_ )</h1>
+      <p>The FindBoundaryBefore abstract operation is called with arguments Intl.Segmenter instance _segmenter_, String value _string_, and integer Number value _startIndex_ to find a segmentation boundary between two code units in _string_ before the code unit at index _startIndex_ according to the locale and options of _segmenter_ and return the immediately following code unit index. The following steps are taken:</p>
+      <emu-note>Boundary determination is implementation-dependent, but general default algorithms are specified in Unicode Standard Annex 29 (available at <a href="https://www.unicode.org/reports/tr29/">https://www.unicode.org/reports/tr29/</a>). It is recommended that implementations use locale-sensitive tailorings such as those provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).</emu-note>
+      <emu-alg>
+        1. Let _locale_ be _segmenter_.[[Locale]].
+        1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
+        1. Assert: _startIndex_ &ge; 0.
+        1. Search _string_ for the last segmentation boundary that is preceded by at most _startIndex_ code units from the beginning, using locale _locale_ and text element granularity _granularity_.
+        1. If a boundary is found,
+          1. Return the count of code units in _string_ preceding the boundary.
+        1. Return *0*.
+      </emu-alg>
+    </emu-clause>
+    <emu-clause id="sec-findboundary-after" aoid="FindBoundaryAfter">
+      <h1>FindBoundaryAfter ( _segmenter_, _string_, _startIndex_ )</h1>
+      <p>The FindBoundaryAfter abstract operation is called with arguments Intl.Segmenter instance _segmenter_, String value _string_, and integer Number value _startIndex_ to find a segmentation boundary between two code units in _string_ after the code unit at index _startIndex_ according to the locale and options of _segmenter_ and return the immediately following code unit index (which will be infinite if no such boundary exists). The following steps are taken:</p>
       <emu-note>Boundary determination is implementation-dependent, but general default algorithms are specified in Unicode Standard Annex 29 (available at <a href="https://www.unicode.org/reports/tr29/">https://www.unicode.org/reports/tr29/</a>). It is recommended that implementations use locale-sensitive tailorings such as those provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org">http://cldr.unicode.org</a>).</emu-note>
       <emu-alg>
         1. Let _locale_ be _segmenter_.[[Locale]].
         1. Let _granularity_ be _segmenter_.[[SegmenterGranularity]].
         1. Let _len_ be the length of _string_.
-        1. If _direction_ is ~before~, then
-          1. Assert: _len_ &gt; 0.
-          1. Assert: _startIndex_ &ge; 0.
-          1. Search _string_ for the last segmentation boundary that is preceded by at most _startIndex_ code units from the beginning, using locale _locale_ and text element granularity _granularity_.
-          1. If a boundary is found, return the count of code units in _string_ preceding it. Otherwise, return *0*.
-        1. Else
-          1. Assert: _direction_ is ~after~.
-          1. If _len_ is 0 or _startIndex_ &ge; _len_, return *+&infin;*.
-          1. Search _string_ for the first segmentation boundary that follows the code unit at index _startIndex_, using locale _locale_ and text element granularity _granularity_.
-          1. If a boundary is found, return the count of code units in _string_ preceding it. Otherwise, return _len_.
+        1. If _len_ is 0 or _startIndex_ &ge; _len_, return *-1*.
+        1. Search _string_ for the first segmentation boundary that follows the code unit at index _startIndex_, using locale _locale_ and text element granularity _granularity_.
+        1. If a boundary is found,
+          1. Return the count of code units in _string_ preceding the boundary.
+        1. Return _len_.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -488,7 +497,7 @@ emu-issue:before {
       In Segmenter:
       <ul>
         <li>
-          Boundary determination algorithms (<emu-xref href="#sec-findboundary"></emu-xref>)
+          Boundary determination algorithms (<emu-xref href="#sec-findboundary-before"></emu-xref>, and <emu-xref href="#sec-findboundary-after"></emu-xref>)
         </li>
         <li>
           Classification of segments as "word-like" (<emu-xref href="#sec-createsegmentdataobject"></emu-xref>)


### PR DESCRIPTION
Split the FindBoundary function.
Simplify the branch
Simplify the text about segment from substring based on
 text found in ecma262
Simplify the text about isWordLike
Use -1 instead of inf to indicate the no boundary found for FindBoundaryAfter
Also see https://github.com/tc39/proposal-intl-segmenter/issues/103