### PR TITLE
Normative: Define Segments instance properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,6 @@ Segments are described by plain objects with the following data properties:
 * `index` is the code unit index in the string at which the segment begins.
 * `isWordLike` is `true` when granularity is "word" and the segment is _word-like_ (consisting of letters/numbers/ideographs/etc.), `false` when granularity is "word" and the segment is not _word-like_ (consisting of spaces/punctuation/etc.), and `undefined` when granularity is not "word".
 
-### Properties of %Segments%.prototype:
-
-#### `get %Segments%.prototype.string`
-
-A read-only accessor property that returns the string input to `Intl.Segmenter.prototype.segment`.
-
 ### Methods of %Segments%.prototype:
 
 #### `%Segments%.prototype.containing(index)`
@@ -108,6 +102,12 @@ Returns a segment data object describing the segment in the string including the
 #### `%Segments%.prototype[Symbol.iterator]`
 
 Creates a new `%SegmentIterator%` instance which will lazily find segments in the input string using the Segmenter's locale and granularity, keeping track of its current position within the string.
+
+### Properties of %Segments% instances
+
+#### `string`
+
+A read-only data property that returns the string input to `Intl.Segmenter.prototype.segment`.
 
 ### Methods of %SegmentIterator%.prototype:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Creates a new `%SegmentIterator%` instance which will lazily find segments in th
 
 ### Properties of %Segments% instances
 
+#### `segmenter`
+
+A read-only data property that returns the constructing `%Segments%` instance.
+
 #### `string`
 
 A read-only data property that returns the string input to `Intl.Segmenter.prototype.segment`.

--- a/spec.html
+++ b/spec.html
@@ -253,6 +253,7 @@ emu-issue:before {
         1. Let _segments_ be ! ObjectCreate(%SegmentsPrototype%, _internalSlotsList_).
         1. Set _segments_.[[SegmentsSegmenter]] to _segmenter_.
         1. Set _segments_.[[SegmentsString]] to _string_.
+        1. Perform ! OrdinaryDefineOwnProperty(_segments_, *"segmenter"*, PropertyDescriptor { [[Value]]: _segmenter_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Perform ! OrdinaryDefineOwnProperty(_segments_, *"string"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _segments_.
       </emu-alg>
@@ -313,6 +314,11 @@ emu-issue:before {
       </p>
 
       <p>Segments instances also have the following properties:</p>
+
+      <emu-clause id="sec-segments.segmenter">
+        <h1>segmenter</h1>
+        <p>The *"segmenter"* property of a Segments instance references the Intl.Segmenter instance that created it. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
 
       <emu-clause id="sec-segments.string">
         <h1>string</h1>

--- a/spec.html
+++ b/spec.html
@@ -253,6 +253,7 @@ emu-issue:before {
         1. Let _segments_ be ! ObjectCreate(%SegmentsPrototype%, _internalSlotsList_).
         1. Set _segments_.[[SegmentsSegmenter]] to _segmenter_.
         1. Set _segments_.[[SegmentsString]] to _string_.
+        1. Perform ! OrdinaryDefineOwnProperty(_segments_, *"string"*, PropertyDescriptor { [[Value]]: _string_, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
         1. Return _segments_.
       </emu-alg>
     </emu-clause>
@@ -283,16 +284,6 @@ emu-issue:before {
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-get-%segmentsprototype%.string">
-        <h1>get %SegmentsPrototype%.string</h1>
-        <p>`%SegmentsPrototype%.string` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:</p>
-        <emu-alg>
-          1. Let _segments_ be *this* value.
-          1. Perform ? RequireInternalSlot(_segments_, [[SegmentsSegmenter]]).
-          1. Return _segments_.[[SegmentsString]].
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-%segmentsprototype%-@@iterator">
         <h1>%SegmentsPrototype% [ @@iterator ] ()</h1>
         <p>The `@@iterator` method is called on a Segments instance to create a Segment Iterator over its string using the locale and options of its constructing Intl.Segmenter instance. The following steps are taken:</p>
@@ -320,6 +311,13 @@ emu-issue:before {
       <p>
         Segments instances have a [[SegmentsString]] internal slot that references the String value whose segments they expose.
       </p>
+
+      <p>Segments instances also have the following properties:</p>
+
+      <emu-clause id="sec-segments.string">
+        <h1>string</h1>
+        <p>The *"string"* property of a Segments instance contains the string being segmented. This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 


### PR DESCRIPTION
Fixes #96

This also changes `string` from a prototype-located getter to an instance-located own data property, to address the ["exotic internal slot" membrane hazard](https://github.com/tc39/proposal-promise-any/issues/38#issuecomment-606963685).