### PR TITLE
Make containing() example unambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ let current = undefined;
 current = segments.containing(0)
 // → { index: 0, segment: "Allons", isWordLike: true }
 
+current = segments.containing(5)
+// → { index: 0, segment: "Allons", isWordLike: true }
+
 current = segments.containing(6)
 // → { index: 6, segment: "-", isWordLike: false }
 


### PR DESCRIPTION
Right now the example does not cover calling `containing` with index in the middle of the segment. Including it makes the example less ambiguous.