### PR TITLE
Normative: Only create isWordLike when granularity is "word"

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -402,9 +402,7 @@ contributors: Richard Gibson, Daniel Ehrenberg
         1. If _granularity_ is `"word"`, then
           1. Let _isWordLike_ be a Boolean value indicating whether the _segment_ in _string_ is "word-like" according to locale _segmenter_.[[Locale]].
           <emu-note>Whether a segment is "word-like" is implementation-dependent, and implementations are recommended to use locale-sensitive tailorings. In general, segments consisting solely of spaces and/or punctuation (such as those terminated with "WORD_NONE" boundaries by ICU [International Components for Unicode, documented at <a href="https://unicode-org.github.io/icu-docs/">https://unicode-org.github.io/icu-docs/</a>]) are not considered to be "word-like".</emu-note>
-        1. Else
-          1. Let _isWordLike_ be *undefined*.
-        1. Perform ! CreateDataPropertyOrThrow(_result_, *"isWordLike"*, _isWordLike_).
+          1. Perform ! CreateDataPropertyOrThrow(_result_, *"isWordLike"*, _isWordLike_).
         1. Return _result_.
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
Close #127